### PR TITLE
Impr/file detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 </div>
 
 ## Installation
+### Using Package
 
 To use `goignore`, you need to have Go (Golang) installed on your system. If you haven't installed Go, you can download and install it from the [official website](https://golang.org/doc/install).
 
@@ -51,6 +52,21 @@ To list all supported programming languages for generating .gitignore files, you
 goignore list
 ````
 This will display a list of supported programming languages.
+
+### Without installing package
+Clone repo to your local directory with the command 
+```sh
+git clone https://github.com/hacktivist123/goignore.git
+```
+Get the executable goignore file by running the command
+```sh
+go build ./goignore/cmd/goignore
+```
+A goignore executable file should be generated for you, you can run all the commands outlined above but this time prepend it with `./`. 
+Example:
+```sh
+./goingore list
+```
 
 ## Contributing
 Contributions to goignore are welcome! If you encounter any issues, have suggestions, or want to contribute improvements, please open an issue or submit a pull request on the GitHub repository.

--- a/cmd/goignore/main.go
+++ b/cmd/goignore/main.go
@@ -48,6 +48,17 @@ var newCmd = &cobra.Command{
 			}
 		}
 
+		// Check if .git repo exists, if not initialize it
+		// _, err := os.Stat(".git")
+		// if err != nil {
+		// 	color.Yellow("Initializing a new Git repository...")
+		// 	err := execCommand("git", "init")
+		// 	if err != nil {
+		// 		color.Red("Error initializing Git repository:", err)
+		// 		return
+		// 	}
+		// }
+
 		// Read .gitignore template content from file
 		templateContent, err := readTemplateFile(language)
 		if err != nil {

--- a/cmd/goignore/main.go
+++ b/cmd/goignore/main.go
@@ -48,17 +48,6 @@ var newCmd = &cobra.Command{
 			}
 		}
 
-		// Check if .git repo exists, if not initialize it
-		_, err := os.Stat(".git")
-		if err != nil {
-			color.Yellow("Initializing a new Git repository...")
-			err := execCommand("git", "init")
-			if err != nil {
-				color.Red("Error initializing Git repository:", err)
-				return
-			}
-		}
-
 		// Read .gitignore template content from file
 		templateContent, err := readTemplateFile(language)
 		if err != nil {

--- a/cmd/goignore/main.go
+++ b/cmd/goignore/main.go
@@ -97,25 +97,25 @@ var listCmd = &cobra.Command{
 }
 
 func detectLanguage() string {
-	files, err := os.ReadDir(".")
-	if err != nil {
-		return ""
-	}
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(file.Name())
+	fileExt := "" 
+	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+        if err != nil {
+            return err
+        }
+		ext := filepath.Ext(path)
 		for lang, exts := range extensions {
 			for _, e := range exts {
 				if ext == e {
-					return lang
+					fileExt = lang
 				}
 			}
 		}
-	}
-	return ""
+		return nil
+    })
+    if err != nil {
+        return ""
+    }
+	return fileExt
 }
 
 func getSupportedLanguages() []string {


### PR DESCRIPTION
1. Searches directory recursively

> This resolves an issue where files are not automatically detected if all your files are inside folders

2. Don't initialize git

> Avoid automatically initializing git in repository which might lead to git being initialized when goignore binary file is just needed to generate gitignore files. For example, I might have goignore binary file in my utilities folder to generate gitignore files to copy and paste inside my projects. Don't want to initialize git in that folder just to generate a gitignore file.

3. Run without installing package.
> Update README.md file with instructions allowing users to use the goignore in other non-golang projects
 