### PR TITLE
Protect new command from undefined arguments

### DIFF
--- a/cmd/goignore/main.go
+++ b/cmd/goignore/main.go
@@ -40,6 +40,13 @@ var rootCmd = &cobra.Command{
 var newCmd = &cobra.Command{
 	Use:   "new",
 	Short: "Generate and add .gitignore file to your project",
+        PreRunE: func(cmd *cobra.Command, args []string) error {
+		   // Check if there are any unexpected arguments
+		   if len(args) > 0 {
+		 	return fmt.Errorf("unexpected arguments: %v", args)
+		         }
+		        return nil
+	           },
 	Run: func(cmd *cobra.Command, args []string) {
 		if language == "" || autoDetect {
 			language = detectLanguage(appFs)


### PR DESCRIPTION
## Why?

This PR fixes a bug where the `goignore new` command could take any random argument and still runs the command. So a check is added to ensure that it doesn't take an undefined argument before it runs. 

## Before
<img width="985" alt="Screenshot 2023-08-06 at 12 22 19 PM" src="https://github.com/hacktivist123/goignore/assets/26572907/55cc2a58-29c1-41f9-8392-3e05cd645da0">


## Now
<img width="925" alt="Screenshot 2023-08-06 at 12 21 57 PM" src="https://github.com/hacktivist123/goignore/assets/26572907/e868ac38-e2e6-4df9-8fa8-7133aa54ee28">